### PR TITLE
Fixes invalid final plan

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:latest
+      image: hashicorp/terraform:1.0.6
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,12 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image: hashicorp/terraform:1.0.6
-      options: '--entrypoint /usr/bin/env'
 
     steps:
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+
       - uses: actions/checkout@v2
 
       - name: Run test
-        run: cd ./test && /bin/bash ./run-test.sh
+        run: run-test.sh
+        working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,9 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Show files in test directory
+        run: ls -l ./test
+
       - name: Run test
         run: ./test/run-test.sh
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run test
-        run: run-test.sh
+        run: ./run-test.sh
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Show files in test directory
         run: |
           pwd
-          ls -l ./test
+          ls -l
         working-directory: test
 
       - name: Run test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,4 +21,5 @@ jobs:
 
       - name: Run test
         run: ./run-test.sh
+        shell: bash
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,5 +26,7 @@ jobs:
         working-directory: test
 
       - name: Run test
-        run: ./test/run-test.sh
+        run: |
+          ls -l
+          ./run-test.sh
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,8 @@ jobs:
       options: '--entrypoint /usr/bin/env'
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Run test
         run: ./run-test.sh
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run test
-        run: ./run-test.sh
+        run: run-test.sh
+        shell: bash
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,5 +18,4 @@ jobs:
 
       - name: Run test
         run: run-test.sh
-        shell: bash
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run test
-        run: cd ./test && source ./run-test.sh
+        run: cd ./test && /bin/bash ./run-test.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
       - name: Run test
         run: ./run-test.sh
-        working-directory: ./test
+        working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,5 @@ jobs:
         working-directory: test
 
       - name: Run test
-        run: |
-          ls -l
-          ./run-test.sh
+        run: ./run-test.sh
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run test
-        run: ./run-test.sh
+        run: ./test/run-test.sh
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: hashicorp/terraform:1.0.6
+      options: '--entrypoint /usr/bin/env'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
     container:
       image: hashicorp/terraform:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   deploy:
-    needs: build
-
     runs-on: ubuntu-latest
     container:
       image: hashicorp/terraform:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,5 +21,4 @@ jobs:
 
       - name: Run test
         run: ./run-test.sh
-        shell: bash
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,14 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Working directory
+        run: pwd
+
       - name: Show files in test directory
-        run: ls -l ./test
+        run: |
+          pwd
+          ls -l ./test
+        working-directory: test
 
       - name: Run test
         run: ./test/run-test.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    needs: build
+
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/terraform:latest
+      options: '--entrypoint /usr/bin/env'
+
+    steps:
+      - name: Run test
+        run: ./run-test.sh
+        working-directory: ./test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run test
-        run: run-test.sh
-        working-directory: test
+        run: |
+          cd ./test
+          ./run-test.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,4 +19,5 @@ jobs:
       - name: Run test
         run: |
           cd ./test
+          ls
           ./run-test.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,15 +16,6 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Working directory
-        run: pwd
-
-      - name: Show files in test directory
-        run: |
-          pwd
-          ls -l
-        working-directory: test
-
       - name: Run test
         run: ./run-test.sh
         working-directory: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,11 +14,10 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
 
-      - uses: actions/checkout@v2
+      - name: Terraform version
+        run: terraform -version
 
-      - name: Show content of the tests script
-        run: cat ./run-test.sh
-        working-directory: test
+      - uses: actions/checkout@v2
 
       - name: Run test
         run: ./run-test.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,13 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: hashicorp/terraform:latest
-      options: '--entrypoint /usr/bin/env'
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Run test
-        run: |
-          cd ./test
-          ls
-          ./run-test.sh
+        run: cd ./test && source ./run-test.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Show content of the tests script
+        run: cat ./run-test.sh
+        working-directory: test
+
       - name: Run test
         run: ./run-test.sh
         working-directory: test

--- a/download.sh
+++ b/download.sh
@@ -3,13 +3,18 @@
 SOURCE=$1
 OUTPUT_PATH=$2
 
-mkdir -p "$(dirname "${OUTPUT_PATH}")";
-wget -q ${SOURCE} -O ${OUTPUT_PATH};
+mkdir -p $(dirname "$OUTPUT_PATH")
+curl -s -S "$SOURCE" --output "$OUTPUT_PATH"
 
 # https://stackoverflow.com/a/39122532/831465
 if [[ $? -ne 0 ]]; then
-  >&2 echo "Failed to download ${SOURCE}"
-  exit 1;
+  >&2 echo "Failed to download $SOURCE"
+  exit 1
 fi
 
-echo "{\"output\":\"${OUTPUT_PATH}\"}";
+# Simply send the output path back to Terraform
+# This ensures that Terraform publishes the file_path to the output after the
+# download is complete
+#
+# See: https://github.com/milliHQ/terraform-npm-download/issues/3
+echo "{\"path\":\"${OUTPUT_PATH}\"}"

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
   cdn_module_url     = "${var.cdn_provider_url}${var.module_name}${local.cdn_module_version}/${var.path_to_file}"
   cdn_download_dest  = "${path.module}/download/${var.module_name}/${var.path_to_file}"
 
-  file_path = var.use_local ? data.external.this[0].result.path : local.cdn_download_dest
+  file_path = var.use_local ? data.external.this[0].result.path : data.external.download[0].result.path
 }
 
 #######################################

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+.terraform.lock.hcl

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,20 @@
+module "npm_download" {
+  source = "../"
+
+  module_name    = "@dealmore/terraform-next-deploy-trigger"
+  module_version = var.package_version
+  path_to_file   = "package.json"
+}
+
+locals {
+  file_missing     = !fileexists(module.npm_download.abs_path)
+  source_code_hash = fileexists(module.npm_download.abs_path) && !local.file_missing ? filebase64sha256(module.npm_download.abs_path) : null
+}
+
+output "file_missing" {
+  value = local.file_missing
+}
+
+output "source_code_hash" {
+  value = local.source_code_hash
+}

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,33 +1,52 @@
 #!/bin/bash
 
-# set -e
+set -e
 
-# TF_IN_AUTOMATION='true'
+# Indicate to Terraform that we run in automation environment
+TF_IN_AUTOMATION='true'
 
-echo "here 1"
+TF_COMMAND='terraform'
+
+if [[ ! -z "$CI" ]]; then
+  # Using terraform-bin instead of terraform in CI to prevent using the wrapper
+  # which causes that the command from the substitution gets saved to the var
+  # e.g. MY_VAR=$(terraform-bin output -json)
+  #
+  # See: https://github.com/hashicorp/setup-terraform/issues/20
+  TF_COMMAND='terraform-bin'
+fi
 
 terraform init -input=false
-terraform apply -input=false -auto-approve
 
-echo "here 2"
+###########
+# First run
+###########
+terraform apply -input=false -auto-approve -var 'package_version=0.0.1'
 
-# output_1=$(terraform output file_missing -no-color)
-
-output_1=$(echo "true")
-
-echo "here 3"
-
-echo "Output: $output_1"
-
-output_2=$(terraform-bin output -json file_missing)
-
-echo ""
-echo "Output 2: $output_2"
+FIRST_RUN_FILE_MISSING=$("$TF_COMMAND" output -no-color file_missing )
+FIRST_RUN_SOURCE_CODE_HASH=$("$TF_COMMAND" output -no-color source_code_hash )
 
 ##
 # File should exist on first apply
 ##
-if [ "$output_1" = "true" ]; then
-  echo "File was missing on apply"
+if [ "$FIRST_RUN_FILE_MISSING" = "true" ] || [ -z "$FIRST_RUN_SOURCE_CODE_HASH" ]; then
+  echo ""
+  echo "Error: File is missing on first apply."
+  exit 1
+fi
+
+############
+# Second run
+############
+terraform apply -input=false -auto-approve -var 'package_version=0.0.2'
+
+SECOND_RUN_SOURCE_CODE_HASH=$("$TF_COMMAND" output -no-color source_code_hash )
+
+##
+# Source code hash should be different between 1st and 2nd run
+##
+if [ "$FIRST_RUN_SOURCE_CODE_HASH" == "$SECOND_RUN_SOURCE_CODE_HASH" ]; then
+  echo ""
+  echo "Error: File has same source code hash on 1. & 2. run."
   exit 1
 fi

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -2,7 +2,7 @@
 
 # set -e
 
-TF_IN_AUTOMATION='true'
+# TF_IN_AUTOMATION='true'
 
 echo "here 1"
 
@@ -11,7 +11,7 @@ terraform apply -input=false -auto-approve
 
 echo "here 2"
 
-output_1=$(terraform output -json | jq -r '.file_missing.value')
+output_1=$(terraform output -json -no-color | jq -r '.file_missing.value')
 
 echo "here 3"
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -11,7 +11,7 @@ terraform apply -input=false -auto-approve
 
 echo "here 2"
 
-output_1=$(terraform output -json -no-color | jq -r '.file_missing.value')
+output_1=$(terraform output file_missing -no-color)
 
 echo "here 3"
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -4,10 +4,14 @@ set -e
 
 TF_IN_AUTOMATION='true'
 
+echo "here 1"
+
 terraform init -input=false
 terraform apply -input=false -auto-approve
 
-FIRST_OUTPUT=$(terraform output -json file_missing)
+echo "here 2"
+
+FIRST_OUTPUT=`terraform output -json file_missing`
 
 echo "Output: $FIRST_OUTPUT"
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -10,6 +10,9 @@ terraform init -input=false
 terraform apply -input=false -auto-approve
 
 echo "here 2"
+terraform output -json file_missing
+
+echo "here 3"
 
 FIRST_OUTPUT=`terraform output -json file_missing`
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+TF_IN_AUTOMATION='true'
+
+terraform init -input=false
+terraform apply -input=false -auto-approve
+
+FIRST_OUTPUT=$(terraform output -json file_missing)
+
+##
+# File should exist on first apply
+##
+if [ "$FIRST_OUTPUT" = "true" ]; then
+  echo "File was missing on apply"
+  exit 1
+fi

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+# set -e
 
 TF_IN_AUTOMATION='true'
 
@@ -14,14 +14,14 @@ terraform output -json file_missing
 
 echo "here 3"
 
-FIRST_OUTPUT=`terraform output -json file_missing`
+test_var=`terraform output -json file_missing`
 
-echo "Output: $FIRST_OUTPUT"
+echo "Output: $test_var"
 
 ##
 # File should exist on first apply
 ##
-if [ "$FIRST_OUTPUT" = "true" ]; then
+if [ "$test_var" = "true" ]; then
   echo "File was missing on apply"
   exit 1
 fi

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -11,7 +11,9 @@ terraform apply -input=false -auto-approve
 
 echo "here 2"
 
-output_1=$(terraform output file_missing -no-color)
+# output_1=$(terraform output file_missing -no-color)
+
+output_1=$(echo "true")
 
 echo "here 3"
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -19,7 +19,7 @@ echo "here 3"
 
 echo "Output: $output_1"
 
-output_2=$(terraform output -raw file_missing)
+output_2=$(terraform-bin output -json file_missing)
 
 echo ""
 echo "Output 2: $output_2"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -10,18 +10,17 @@ terraform init -input=false
 terraform apply -input=false -auto-approve
 
 echo "here 2"
-terraform output -json file_missing
+
+output_1=$(terraform output -json | jq -r '.file_missing.value')
 
 echo "here 3"
 
-test_var=`terraform output -json file_missing`
-
-echo "Output: $test_var"
+echo "Output: $output_1"
 
 ##
 # File should exist on first apply
 ##
-if [ "$test_var" = "true" ]; then
+if [ "$output_1" = "true" ]; then
   echo "File was missing on apply"
   exit 1
 fi

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -19,6 +19,11 @@ echo "here 3"
 
 echo "Output: $output_1"
 
+output_2=$(terraform output -raw file_missing)
+
+echo ""
+echo "Output 2: $output_2"
+
 ##
 # File should exist on first apply
 ##

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -9,6 +9,8 @@ terraform apply -input=false -auto-approve
 
 FIRST_OUTPUT=$(terraform output -json file_missing)
 
+echo "Output: $FIRST_OUTPUT"
+
 ##
 # File should exist on first apply
 ##

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -1,3 +1,3 @@
 variable "package_version" {
-  type    = string
+  type = string
 }

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -1,4 +1,4 @@
 variable "package_version" {
-  type = string
+  type    = string
   default = "0.0.2"
 }

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -1,0 +1,4 @@
+variable "package_version" {
+  type = string
+  default = "0.0.2"
+}

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -1,4 +1,3 @@
 variable "package_version" {
   type    = string
-  default = "0.0.2"
 }


### PR DESCRIPTION
This should fix two scenarios:

- On first `terraform apply` the output `path_to_file` should only be published **after** the file is downloaded
- On a second `terraform apply` when the downloaded content has changed, the output `path_to_file` should only be published after the content of the file has changed

Closes #3.